### PR TITLE
[WIP] Be able to use Terraform in CloudFormation templates

### DIFF
--- a/templates/cloudformation-terraform-custom-resource/README.md
+++ b/templates/cloudformation-terraform-custom-resource/README.md
@@ -9,8 +9,23 @@
 
 ## Terraform outputs
 
-TBD
+Terraform outputs are passed 1:1 to CloudFormation so you can use it with the `Fn::GetAtt` method, e.g.
 
+```yaml
+  TerraFormCustomResource:
+    DependsOn: TerraFormExecuteFunction
+    Type: Custom::TerraFormExecute
+    Properties:
+      Terraform: |
+        ... 
+        output "SomeOutput" {
+          value = "some_value"
+        }
+```
+could be accessed with
+```yaml
+!GetAtt TerraFormCustomResource.SomeOutput
+```
 ## Known issues
 
  - [`AWS::Include`](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/create-reusable-transform-function-snippets-and-add-to-your-template-with-aws-include-transform.html) might be used to include the Terraform Lambda function snippet in order to avoid copy and paste

--- a/templates/cloudformation-terraform-custom-resource/README.md
+++ b/templates/cloudformation-terraform-custom-resource/README.md
@@ -1,6 +1,7 @@
 ## Why?
 
- - CloudFormation is nice because it manages state and has an API
+ - CloudFormation is nice because it takes care of state management and has an API. In terms of tool usage I always try to lower the total cost of ownership. Terraform has definetely a higher total cost of ownership.
+ - I'd like to have the union set of both tools in terms of resource coverage.
  - Terraform is nice because it supports more resources
  - Why not combine both in order to have the highest feature richness combined with lowest TCO
  - I don't want to reimplement functionality that is already in Terraform or CloudFormation - so I just wrote a couple of lines of glue code.

--- a/templates/cloudformation-terraform-custom-resource/README.md
+++ b/templates/cloudformation-terraform-custom-resource/README.md
@@ -1,3 +1,11 @@
+## Why?
+
+ - CloudFormation is nice because it manages state and has an API
+ - Terraform is nice because it supports more resources
+ - Why not combine both in order to have the highest feature richness combined with lowest TCO
+
+(TODO: checkout my own TF article for more arguments )
+
 ## Known issues
 
  - [`AWS::Include`](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/create-reusable-transform-function-snippets-and-add-to-your-template-with-aws-include-transform.html) might be used to include the Terraform Lambda function snippet in order to avoid copy and paste

--- a/templates/cloudformation-terraform-custom-resource/README.md
+++ b/templates/cloudformation-terraform-custom-resource/README.md
@@ -3,6 +3,7 @@
  - CloudFormation is nice because it manages state and has an API
  - Terraform is nice because it supports more resources
  - Why not combine both in order to have the highest feature richness combined with lowest TCO
+ - I don't want to reimplement functionality that is already in Terraform or CloudFormation - so I just wrote a couple of lines of glue code.
 
 (TODO: checkout my own TF article for more arguments )
 

--- a/templates/cloudformation-terraform-custom-resource/README.md
+++ b/templates/cloudformation-terraform-custom-resource/README.md
@@ -1,0 +1,3 @@
+## Known issues
+
+ - [`AWS::Include`](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/create-reusable-transform-function-snippets-and-add-to-your-template-with-aws-include-transform.html) might be used to include the Terraform Lambda function snippet in order to avoid copy and paste

--- a/templates/cloudformation-terraform-custom-resource/README.md
+++ b/templates/cloudformation-terraform-custom-resource/README.md
@@ -8,6 +8,14 @@
 
 (TODO: checkout my own TF article for more arguments )
 
+## Features
+
+ - Execute arbitrary Terraform code in CloudFormation
+ - Pass parameters from CloudFormation to Terraform
+ - Use outputs from Terraform in CloudFormation (e.g. the ID of a created resource).
+ - Creation, update and delete is supported
+ - Keeps care of Terraform state file handling by providing a private S3 bucket for storage
+
 ## Terraform outputs
 
 Terraform outputs are passed 1:1 to CloudFormation so you can use it with the `Fn::GetAtt` method, e.g.

--- a/templates/cloudformation-terraform-custom-resource/README.md
+++ b/templates/cloudformation-terraform-custom-resource/README.md
@@ -6,6 +6,10 @@
 
 (TODO: checkout my own TF article for more arguments )
 
+## Terraform outputs
+
+TBD
+
 ## Known issues
 
  - [`AWS::Include`](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/create-reusable-transform-function-snippets-and-add-to-your-template-with-aws-include-transform.html) might be used to include the Terraform Lambda function snippet in order to avoid copy and paste

--- a/templates/cloudformation-terraform-custom-resource/template.yaml
+++ b/templates/cloudformation-terraform-custom-resource/template.yaml
@@ -32,11 +32,9 @@ Resources:
               os.makedirs(terraform_working_directory, exist_ok=True)
               open(os.path.join(terraform_working_directory, 'terraform.tf'), 'w').write(event['ResourceProperties']['Terraform'])
 
-              # chdir for terraform to find its files
-              os.chdir(terraform_working_directory)
               try:
-                subprocess.check_output('/tmp/terraform init', shell=True)
-                print(subprocess.check_output('/tmp/terraform plan', stderr=subprocess.STDOUT, shell=True))
+                subprocess.check_output('/tmp/terraform init', shell=True, cwd=terraform_working_directory)
+                print(subprocess.check_output('/tmp/terraform plan', stderr=subprocess.STDOUT, shell=True, cwd=terraform_working_directory))
               except subprocess.CalledProcessError as exc:
                 print("Status : FAILED", exc.returncode, exc.output)
                 # TODO: add response data

--- a/templates/cloudformation-terraform-custom-resource/template.yaml
+++ b/templates/cloudformation-terraform-custom-resource/template.yaml
@@ -34,7 +34,6 @@ Resources:
 
               try:
                 subprocess.check_output('/tmp/terraform init', shell=True, cwd=terraform_working_directory)
-                print(subprocess.check_output('/tmp/terraform plan', stderr=subprocess.STDOUT, shell=True, cwd=terraform_working_directory))
                 print(subprocess.check_output('/tmp/terraform apply', stderr=subprocess.STDOUT, shell=True, cwd=terraform_working_directory))
 
                 terraform_outputs = json.loads(subprocess.check_output('/tmp/terraform output -json', stderr=subprocess.STDOUT, shell=True, cwd=terraform_working_directory))

--- a/templates/cloudformation-terraform-custom-resource/template.yaml
+++ b/templates/cloudformation-terraform-custom-resource/template.yaml
@@ -25,7 +25,7 @@ Resources:
               #print(subprocess.check_output('/tmp/terraform version', shell=True))
 
               if event['RequestType'] == 'Delete':
-                  cfnresponse.send(event=event, context=context, responseStatus=cfnresponse.SUCCESS, responseData={})
+                  cfnresponse.send(event=event, context=context, responseStatus=cfnresponse.SUCCESS, responseData={}, physicalResourceId=event['LogicalResourceId'])
                   return
 
               # write terraform file
@@ -38,10 +38,10 @@ Resources:
               except subprocess.CalledProcessError as exc:
                 print("Status : FAILED", exc.returncode, exc.output)
                 # TODO: add response data
-                cfnresponse.send(event=event, context=context, responseStatus=cfnresponse.FAILED, responseData={})
+                cfnresponse.send(event=event, context=context, responseStatus=cfnresponse.FAILED, responseData={}, physicalResourceId=event['LogicalResourceId'])
                 return
 
-              cfnresponse.send(event=event, context=context, responseStatus=cfnresponse.SUCCESS, responseData={})
+              cfnresponse.send(event=event, context=context, responseStatus=cfnresponse.SUCCESS, responseData={}, physicalResourceId=event['LogicalResourceId'])
 
       Handler: index.handler
       Runtime: python3.6

--- a/templates/cloudformation-terraform-custom-resource/template.yaml
+++ b/templates/cloudformation-terraform-custom-resource/template.yaml
@@ -1,0 +1,45 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+
+Resources:
+  TerraFormExecuteFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        ZipFile: |
+          import boto3
+          import time
+          import json
+          import cfnresponse
+
+          def handler(event, context):
+              print("Received event: " + json.dumps(event, indent=2))
+
+              if event['RequestType'] == 'Delete':
+                  cfnresponse.send(event=event, context=context, responseStatus=cfnresponse.SUCCESS, responseData={})
+                  return
+              cfnresponse.send(event=event, context=context, responseStatus=cfnresponse.SUCCESS, responseData={})
+
+      Handler: index.handler
+      Runtime: python3.6
+      Timeout: 300
+      Role: !GetAtt TerraFormExecuteFunctionRole.Arn
+
+  TerraFormExecuteFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
+  TerraFormCustomResource:
+    Type: Custom::TerraFormExecute
+    Properties:
+      ServiceToken: !GetAtt TerraFormExecuteFunction.Arn
+      StackName: !Ref AWS::StackName

--- a/templates/cloudformation-terraform-custom-resource/template.yaml
+++ b/templates/cloudformation-terraform-custom-resource/template.yaml
@@ -17,6 +17,8 @@ Resources:
           def handler(event, context):
               print("Received event: " + json.dumps(event, indent=2))
 
+              terraform_working_directory = '/tmp/terraform_files'
+
               # TODO: sha check
               subprocess.check_output('curl https://releases.hashicorp.com/terraform/0.10.0/terraform_0.10.0_linux_amd64.zip > /tmp/terraform.zip', shell=True)
               subprocess.check_output('unzip -o -d /tmp /tmp/terraform.zip', shell=True)
@@ -27,11 +29,11 @@ Resources:
                   return
 
               # write terraform file
-              os.makedirs('/tmp/terraform_files/', exist_ok=True)
-              open('/tmp/terraform_files/terraform.tf', 'w').write(event['ResourceProperties']['Terraform'])
+              os.makedirs(terraform_working_directory, exist_ok=True)
+              open(os.path.join(terraform_working_directory, 'terraform.tf'), 'w').write(event['ResourceProperties']['Terraform'])
 
               # chdir for terraform to find its files
-              os.chdir('/tmp/terraform_files')
+              os.chdir(terraform_working_directory)
               try:
                 subprocess.check_output('/tmp/terraform init', shell=True)
                 print(subprocess.check_output('/tmp/terraform plan', stderr=subprocess.STDOUT, shell=True))

--- a/templates/cloudformation-terraform-custom-resource/template.yaml
+++ b/templates/cloudformation-terraform-custom-resource/template.yaml
@@ -11,6 +11,7 @@ Resources:
           import time
           import json
           import cfnresponse
+          import subprocess
 
           def handler(event, context):
               print("Received event: " + json.dumps(event, indent=2))

--- a/templates/cloudformation-terraform-custom-resource/template.yaml
+++ b/templates/cloudformation-terraform-custom-resource/template.yaml
@@ -16,6 +16,10 @@ Resources:
           def handler(event, context):
               print("Received event: " + json.dumps(event, indent=2))
 
+              subprocess.check_output('curl https://releases.hashicorp.com/terraform/0.10.0/terraform_0.10.0_linux_amd64.zip > /tmp/terraform.zip', shell=True)
+              subprocess.check_output('unzip -d /tmp /tmp/terraform.zip', shell=True)
+              print(subprocess.check_output('/tmp/terraform version', shell=True))
+
               if event['RequestType'] == 'Delete':
                   cfnresponse.send(event=event, context=context, responseStatus=cfnresponse.SUCCESS, responseData={})
                   return

--- a/templates/cloudformation-terraform-custom-resource/template.yaml
+++ b/templates/cloudformation-terraform-custom-resource/template.yaml
@@ -37,7 +37,10 @@ Resources:
                 print(subprocess.check_output('/tmp/terraform plan', stderr=subprocess.STDOUT, shell=True, cwd=terraform_working_directory))
                 print(subprocess.check_output('/tmp/terraform apply', stderr=subprocess.STDOUT, shell=True, cwd=terraform_working_directory))
 
-                cfnresponse.send(event=event, context=context, responseStatus=cfnresponse.SUCCESS, responseData={}, physicalResourceId=event['LogicalResourceId'])
+                terraform_outputs = json.loads(subprocess.check_output('/tmp/terraform output -json', stderr=subprocess.STDOUT, shell=True, cwd=terraform_working_directory))
+                response_data = {key: value['value'] for key, value in terraform_outputs.items()}
+
+                cfnresponse.send(event=event, context=context, responseStatus=cfnresponse.SUCCESS, responseData=response_data, physicalResourceId=event['LogicalResourceId'])
 
               except subprocess.CalledProcessError as exc:
                 print("Status : FAILED", exc.returncode, exc.output)
@@ -113,3 +116,16 @@ Resources:
         resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {
           comment = "I am a resource managed by Terraform!"
         }
+
+        output "cloudfront_oia_arn" {
+          value = "${!aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn}"
+        }
+
+        output "cloudfront_oia_path" {
+          value = "${!aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
+        }
+
+Outputs:
+  Test:
+    Description: test
+    Value: !GetAtt TerraFormCustomResource.cloudfront_oia_path

--- a/templates/cloudformation-terraform-custom-resource/template.yaml
+++ b/templates/cloudformation-terraform-custom-resource/template.yaml
@@ -20,7 +20,7 @@ Resources:
               terraform_working_directory = '/tmp/terraform_files'
 
               # TODO: sha check
-              subprocess.check_output('curl https://releases.hashicorp.com/terraform/0.10.0/terraform_0.10.0_linux_amd64.zip > /tmp/terraform.zip', shell=True)
+              subprocess.check_output('curl -o /tmp/terraform.zip https://releases.hashicorp.com/terraform/0.10.0/terraform_0.10.0_linux_amd64.zip', shell=True)
               subprocess.check_output('unzip -o -d /tmp /tmp/terraform.zip', shell=True)
               #print(subprocess.check_output('/tmp/terraform version', shell=True))
 

--- a/templates/cloudformation-terraform-custom-resource/template.yaml
+++ b/templates/cloudformation-terraform-custom-resource/template.yaml
@@ -12,17 +12,35 @@ Resources:
           import json
           import cfnresponse
           import subprocess
+          import os
 
           def handler(event, context):
               print("Received event: " + json.dumps(event, indent=2))
 
+              # TODO: sha check
               subprocess.check_output('curl https://releases.hashicorp.com/terraform/0.10.0/terraform_0.10.0_linux_amd64.zip > /tmp/terraform.zip', shell=True)
-              subprocess.check_output('unzip -d /tmp /tmp/terraform.zip', shell=True)
-              print(subprocess.check_output('/tmp/terraform version', shell=True))
+              subprocess.check_output('unzip -o -d /tmp /tmp/terraform.zip', shell=True)
+              #print(subprocess.check_output('/tmp/terraform version', shell=True))
 
               if event['RequestType'] == 'Delete':
                   cfnresponse.send(event=event, context=context, responseStatus=cfnresponse.SUCCESS, responseData={})
                   return
+
+              # write terraform file
+              os.makedirs('/tmp/terraform_files/', exist_ok=True)
+              open('/tmp/terraform_files/terraform.tf', 'w').write(event['ResourceProperties']['Terraform'])
+
+              # chdir for terraform to find its files
+              os.chdir('/tmp/terraform_files')
+              try:
+                subprocess.check_output('/tmp/terraform init', shell=True)
+                print(subprocess.check_output('/tmp/terraform plan', stderr=subprocess.STDOUT, shell=True))
+              except subprocess.CalledProcessError as exc:
+                print("Status : FAILED", exc.returncode, exc.output)
+                # TODO: add response data
+                cfnresponse.send(event=event, context=context, responseStatus=cfnresponse.FAILED, responseData={})
+                return
+
               cfnresponse.send(event=event, context=context, responseStatus=cfnresponse.SUCCESS, responseData={})
 
       Handler: index.handler
@@ -43,8 +61,26 @@ Resources:
       ManagedPolicyArns:
       - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
 
+  TerraformExecutionPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: AllowCloudFrontAccess
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+            - 'cloudfront:'
+            Resource: "*"
+      Roles:
+      - !Ref TerraFormExecuteFunctionRole
+
   TerraFormCustomResource:
+    DependsOn: TerraFormExecuteFunction
     Type: Custom::TerraFormExecute
     Properties:
       ServiceToken: !GetAtt TerraFormExecuteFunction.Arn
-      StackName: !Ref AWS::StackName
+      Terraform: !Sub |
+        resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {
+          comment = "I am a resource managed by Terraform!"
+        }

--- a/templates/cloudformation-terraform-custom-resource/template.yaml
+++ b/templates/cloudformation-terraform-custom-resource/template.yaml
@@ -35,18 +35,27 @@ Resources:
               try:
                 subprocess.check_output('/tmp/terraform init', shell=True, cwd=terraform_working_directory)
                 print(subprocess.check_output('/tmp/terraform plan', stderr=subprocess.STDOUT, shell=True, cwd=terraform_working_directory))
+                print(subprocess.check_output('/tmp/terraform apply', stderr=subprocess.STDOUT, shell=True, cwd=terraform_working_directory))
+
+                cfnresponse.send(event=event, context=context, responseStatus=cfnresponse.SUCCESS, responseData={}, physicalResourceId=event['LogicalResourceId'])
+
               except subprocess.CalledProcessError as exc:
                 print("Status : FAILED", exc.returncode, exc.output)
                 # TODO: add response data
                 cfnresponse.send(event=event, context=context, responseStatus=cfnresponse.FAILED, responseData={}, physicalResourceId=event['LogicalResourceId'])
                 return
 
-              cfnresponse.send(event=event, context=context, responseStatus=cfnresponse.SUCCESS, responseData={}, physicalResourceId=event['LogicalResourceId'])
 
       Handler: index.handler
       Runtime: python3.6
       Timeout: 300
       Role: !GetAtt TerraFormExecuteFunctionRole.Arn
+
+  TerraFormStateStorage:
+    Type: AWS::S3::Bucket
+    Properties:
+      VersioningConfiguration:
+        Status: Enabled
 
   TerraFormExecuteFunctionRole:
     Type: AWS::IAM::Role
@@ -60,7 +69,19 @@ Resources:
           Action: sts:AssumeRole
       ManagedPolicyArns:
       - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
-
+      Policies:
+      - PolicyName: AllowWriteAndReadTerraformStateStorage
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - s3:Put*
+            - s3:Get*
+            - s3:List*
+            Resource:
+            - !GetAtt TerraFormStateStorage.Arn
+            - !Sub '${TerraFormStateStorage.Arn}/*'
   TerraformExecutionPolicy:
     Type: AWS::IAM::Policy
     Properties:
@@ -70,8 +91,8 @@ Resources:
         Statement:
           - Effect: Allow
             Action:
-            - 'cloudfront:'
-            Resource: "*"
+            - cloudfront:*
+            Resource: '*'
       Roles:
       - !Ref TerraFormExecuteFunctionRole
 
@@ -81,6 +102,14 @@ Resources:
     Properties:
       ServiceToken: !GetAtt TerraFormExecuteFunction.Arn
       Terraform: !Sub |
+        terraform {
+          backend "s3" {
+            bucket = "${TerraFormStateStorage}"
+            key    = "terraform.tfstate"
+            region = "${AWS::Region}"
+          }
+        }
+
         resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {
           comment = "I am a resource managed by Terraform!"
         }


### PR DESCRIPTION
In order to make use of the low total cost of ownership, easy one-click-setup features etc of CloudFormation (fully managed by AWS) and also the feature and resource richness of Terraform
I want to combine both with CloudFormation as "inception point"
For those who want to save setup time and maintenance overhead by using one-click CloudFormation templates without manual setup instructions (e.g. install terraform and so on)
Whereas currently there seems to be either Terraform or CloudFormation

TODO:

- [ ] Make use of https://www.terraform.io/docs/state/workspaces.html ?
- [ ] Input variables to terraform (already possible via !Sub - but could be made nicer with passing them from CFN)
- [ ] Remove echos in code
- [ ] Output variables
  - [ ] Also make it work when no outputs are there
- [ ] Are Changesets possible?
- [x] Store state in S3
  - [ ] crypted
  - [ ] move out of terraform code (move to own file in Lambda func?)
- [ ] Implement delete
- [ ] Allow only one TF resource?
- [ ] SHA check of TF executable